### PR TITLE
Update requirements

### DIFF
--- a/install-oasys.sh
+++ b/install-oasys.sh
@@ -22,10 +22,10 @@ conda update --yes conda pip
 
 echo "Installing additional pre-built packages"
 conda install --yes \
-	pyqt=4 \
+	pyqt \
 	numpy \
 	scipy \
-	matplotlib=1.4.3 \
+	matplotlib \
 	python-dateutil \
 	pytz \
 	pyparsing \
@@ -81,7 +81,7 @@ cd ..
 
 
 echo "Installing Oasys..."
-pip install oasys
+pip install oasys1
 
 exit
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - -


### PR DESCRIPTION
Hi,

I found that ptqt4 is no longer in anaconda and as far as I can tell the new pyqt5-compatible package on pypi is oasys1. Finally, the matplotlib version previously pinned is not compatible with the default version of numpy.